### PR TITLE
Actually build on all supported PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: php
 
+# php version to use for travis' composer & coverage
 php:
-  - 7.0
   - 7.1
-  - 7.2
-
-sudo: false
 
 services:
   - docker
@@ -18,7 +15,6 @@ script:
   - make ci
 
 after_success:
-  - if [[ "`phpenv version-name`" != "7.1" ]]; then exit 0; fi
   - vendor/bin/phpunit --coverage-clover coverage.clover
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM php:7.1-cli
+ARG PHP_VERSION
+
+FROM php:${PHP_VERSION}-cli
 
 RUN \
 	apt-get update && \

--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,18 @@ test: covers phpunit
 cs: phpcs stan
 
 phpunit:
-	docker-compose run --rm app ./vendor/bin/phpunit
+	docker-compose run --rm email-address-7.0 ./vendor/bin/phpunit
+	docker-compose run --rm email-address-7.1 ./vendor/bin/phpunit
+	docker-compose run --rm email-address-7.2 ./vendor/bin/phpunit
 
 phpcs:
-	docker-compose run --rm app ./vendor/bin/phpcs
+	docker-compose run --rm email-address-7.1 ./vendor/bin/phpcs
 
 stan:
-	docker-compose run --rm app ./vendor/bin/phpstan analyse --level=1 --no-progress src/ tests/
+	docker-compose run --rm email-address-7.1 ./vendor/bin/phpstan analyse --level=1 --no-progress src/ tests/
 
 covers:
-	docker-compose run --rm app ./vendor/bin/covers-validator
+	docker-compose run --rm email-address-7.1 ./vendor/bin/covers-validator
 
 composer:
 	docker run --rm --interactive --tty --volume $(shell pwd):/app -w /app\

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,28 @@
 version: '2'
 
 services:
-  app:
-    build: .
+  email-address-7.0:
+    build:
+      context: .
+      args:
+        PHP_VERSION: 7.0
     volumes:
       - ./:/usr/src/app
     working_dir: /usr/src/app
+    image: wmde/email-address:7.0
+
+  email-address-7.1:
+    extends:
+      service: email-address-7.0
+    build:
+      args:
+        PHP_VERSION: 7.1
+    image: wmde/email-address:7.1
+
+  email-address-7.2:
+    extends:
+      service: email-address-7.0
+    build:
+      args:
+        PHP_VERSION: 7.2
+    image: wmde/email-address:7.2

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -4,6 +4,9 @@ declare( strict_types = 1 );
 
 namespace WMDE\EmailAddress;
 
+use const IDNA_NONTRANSITIONAL_TO_ASCII;
+use const INTL_IDNA_VARIANT_UTS46;
+
 /**
  * @licence GNU GPL v2+
  * @author Christoph Fischer < christoph.fischer@wikimedia.de >
@@ -38,7 +41,7 @@ class EmailAddress {
 	}
 
 	public function getNormalizedDomain(): string {
-		return (string)idn_to_ascii( $this->domain );
+		return (string)idn_to_ascii( $this->domain, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46 );
 	}
 
 	public function getFullAddress(): string {


### PR DESCRIPTION
Previous addition of php versions to `.travis.yml` file did not cause actual build on those php version, as tests were invoked inside a (7.1) container only.