### PR TITLE
replace discontinued service name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ To run just the PHPUnit tests run
 
 To run only a subset of PHPUnit tests or otherwise pass flags to PHPUnit, run
 
-    docker-compose run --rm app ./vendor/bin/phpunit --filter SomeClassNameOrFilter
+    docker-compose run --rm email-address-7.1 ./vendor/bin/phpunit --filter SomeClassNameOrFilter


### PR DESCRIPTION
Now [references](https://github.com/wmde/email-address/blob/fix-readme/docker-compose.yml#L14) our current prod version - it's an example; any existing service should be fine.