### PR TITLE
Add test matrix to the Woodpecker CI config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    reviewers:
+      - "wmde/funtech-core"

--- a/.woodpecker/ci.yaml
+++ b/.woodpecker/ci.yaml
@@ -1,8 +1,13 @@
+matrix:
+    CONTAINER_IMAGE:
+        - registry.gitlab.com/fun-tech/fundraising-frontend-docker:latest
+        - registry.gitlab.com/fun-tech/fundraising-frontend-docker/php-8.4:latest
+
 steps:
     - name: build
       when:
           - event: [ push, pull_request, cron, manual ]
-      image: registry.gitlab.com/fun-tech/fundraising-frontend-docker:latest
+      image: ${CONTAINER_IMAGE}
       environment:
           COMPOSER_CACHE_DIR: /composer_cache
           GITHUB_TOKEN:


### PR DESCRIPTION
- the test matrix allows us to run our workflow with seperate images
https://woodpecker-ci.org/docs/usage/matrix-workflows#example-matrix-pipeline-based-on-docker-image-tag
- part of the update to php8.4


- add funtech as reviewers for dependabot PRs

Ticket https://phabricator.wikimedia.org/T387970